### PR TITLE
Add HTML currency converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
 # gpt-2
+
+This repository contains simple utilities. The `currency_converter.py` script
+provides real-time currency conversion between Russian rubles (RUB), euros
+(EUR), US dollars (USD), and Kazakhstani tenge (KZT). It fetches current rates
+from the [exchangerate.host](https://exchangerate.host) API.
+
+## Usage (Python)
+
+Run the script with Python and follow the prompts:
+
+```bash
+python currency_converter.py
+```
+
+You'll be asked for the amount, the source currency, and the target currency.
+The script outputs the converted amount using the latest available exchange
+rate.
+
+## Usage (HTML)
+
+Open `currency_converter.html` in a web browser. Enter the amount and select the
+source and target currencies. Click **Convert** to fetch the latest rate and see
+results directly in the page.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository contains simple utilities. The `currency_converter.py` script
 provides real-time currency conversion between Russian rubles (RUB), euros
 (EUR), US dollars (USD), and Kazakhstani tenge (KZT). It fetches current rates
-from the [exchangerate.host](https://exchangerate.host) API.
+from the [ExchangeRate-API](https://open.er-api.com/).
 
 ## Usage (Python)
 

--- a/currency_converter.html
+++ b/currency_converter.html
@@ -35,13 +35,15 @@ document.getElementById('convert').addEventListener('click', async () => {
     const amount = document.getElementById('amount').value;
     const from = document.getElementById('from').value;
     const to = document.getElementById('to').value;
-    const url = `https://api.exchangerate.host/convert?from=${from}&to=${to}&amount=${amount}`;
+    const url = `https://open.er-api.com/v6/latest/${from}`;
     try {
         const resp = await fetch(url);
         if (!resp.ok) throw new Error('Network response was not ok');
         const data = await resp.json();
-        if (data.result === null) throw new Error('Unexpected API response');
-        document.getElementById('result').innerText = `${amount} ${from} = ${data.result.toFixed(2)} ${to}`;
+        const rate = data.rates && data.rates[to];
+        if (!rate) throw new Error('Unexpected API response');
+        const result = (amount * rate).toFixed(2);
+        document.getElementById('result').innerText = `${amount} ${from} = ${result} ${to}`;
     } catch (err) {
         document.getElementById('result').innerText = 'Error fetching rates';
         console.error(err);

--- a/currency_converter.html
+++ b/currency_converter.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Currency Converter</title>
+<style>
+body { font-family: Arial, sans-serif; margin: 40px; }
+label { display: block; margin: 10px 0 5px; }
+input, select { padding: 5px; }
+#result { margin-top: 20px; font-weight: bold; }
+</style>
+</head>
+<body>
+<h1>Real-Time Currency Converter</h1>
+<label for="amount">Amount:</label>
+<input type="number" id="amount" step="any" value="1">
+<label for="from">From:</label>
+<select id="from">
+  <option value="RUB">RUB</option>
+  <option value="EUR">EUR</option>
+  <option value="USD" selected>USD</option>
+  <option value="KZT">KZT</option>
+</select>
+<label for="to">To:</label>
+<select id="to">
+  <option value="RUB">RUB</option>
+  <option value="EUR" selected>EUR</option>
+  <option value="USD">USD</option>
+  <option value="KZT">KZT</option>
+</select>
+<button id="convert">Convert</button>
+<div id="result"></div>
+<script>
+document.getElementById('convert').addEventListener('click', async () => {
+    const amount = document.getElementById('amount').value;
+    const from = document.getElementById('from').value;
+    const to = document.getElementById('to').value;
+    const url = `https://api.exchangerate.host/convert?from=${from}&to=${to}&amount=${amount}`;
+    try {
+        const resp = await fetch(url);
+        if (!resp.ok) throw new Error('Network response was not ok');
+        const data = await resp.json();
+        if (data.result === null) throw new Error('Unexpected API response');
+        document.getElementById('result').innerText = `${amount} ${from} = ${data.result.toFixed(2)} ${to}`;
+    } catch (err) {
+        document.getElementById('result').innerText = 'Error fetching rates';
+        console.error(err);
+    }
+});
+</script>
+</body>
+</html>

--- a/currency_converter.py
+++ b/currency_converter.py
@@ -1,0 +1,30 @@
+import requests
+
+CURRENCIES = ['RUB', 'EUR', 'USD', 'KZT']
+
+
+def convert(amount, from_currency, to_currency):
+    if from_currency not in CURRENCIES:
+        raise ValueError(f"Unsupported currency: {from_currency}")
+    if to_currency not in CURRENCIES:
+        raise ValueError(f"Unsupported currency: {to_currency}")
+    url = (
+        f"https://api.exchangerate.host/convert"
+        f"?from={from_currency}&to={to_currency}&amount={amount}"
+    )
+    resp = requests.get(url)
+    resp.raise_for_status()
+    data = resp.json()
+    return data.get('result')
+
+
+if __name__ == '__main__':
+    print("Available currencies:", ', '.join(CURRENCIES))
+    amount = float(input("Amount: "))
+    from_currency = input("From currency: ").upper()
+    to_currency = input("To currency: ").upper()
+    try:
+        result = convert(amount, from_currency, to_currency)
+        print(f"{amount} {from_currency} = {result:.2f} {to_currency}")
+    except Exception as e:
+        print("Error:", e)

--- a/currency_converter.py
+++ b/currency_converter.py
@@ -8,14 +8,14 @@ def convert(amount, from_currency, to_currency):
         raise ValueError(f"Unsupported currency: {from_currency}")
     if to_currency not in CURRENCIES:
         raise ValueError(f"Unsupported currency: {to_currency}")
-    url = (
-        f"https://api.exchangerate.host/convert"
-        f"?from={from_currency}&to={to_currency}&amount={amount}"
-    )
+    url = f"https://open.er-api.com/v6/latest/{from_currency}"
     resp = requests.get(url)
     resp.raise_for_status()
     data = resp.json()
-    return data.get('result')
+    rates = data.get('rates')
+    if rates is None or to_currency not in rates:
+        raise ValueError('Unexpected API response')
+    return amount * rates[to_currency]
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- add a browser-based currency converter using exchangerate.host
- document usage of the HTML page

## Testing
- `python currency_converter.py <<EOF
1
USD
RUB
EOF` *(fails: ProxyError 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6844420819ec8332a5fa30a7a5273207